### PR TITLE
add support to select the alt boot pin between PA5(HD0) and PA13(SCK) with -b option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Usage: wch-ch56x-isp [OPTION]...
   -p, --progress            Display progress
   -v, --verify              Do verify after erase/program
   -r, --reset               Reset MCU at end
+  -b, --altbootpin=VALUE    Set alt boot pin on(PA13) or off(PA5), will INVALID the image inside
   -d, --mcudebug=VALUE      Set MCU debug mode on or off
   -f, --flashfile=VALUE     Flash file (binary file *.bin)
 ```


### PR DESCRIPTION
wch569 use PA5 as boot pin default, but the WCHISPStudio can choose PA13 instead.

I did not find any implement exists, so after a little dump and reverse, there it is.